### PR TITLE
+ First pass at an algorithm to turn flat comments array into threaded comments

### DIFF
--- a/Mlem/Logic/Server Response Parsing/Comment Parser.swift
+++ b/Mlem/Logic/Server Response Parsing/Comment Parser.swift
@@ -10,179 +10,52 @@ import SwiftyJSON
 
 func parseComments(commentResponse: String, instanceLink: URL) async throws -> [Comment]
 {
-    var commentTracker: Set<Comment> = .init()
-    
     do
     {
         let parsedJSON: JSON = try parseJSON(from: commentResponse)
-        
-        let commentArray = parsedJSON["data", "comments"].arrayValue
-        
-        if instanceLink.absoluteString.contains("v1")
+        let jsonComments = parsedJSON["data", "comments"].arrayValue
+
+        let isV1 = instanceLink.absoluteString.contains("v1")
+        var allComments = jsonComments.map { isV1 ? $0.v1ToComment() : $0.v2ToComment() }
+
+        let childrenStartIndex = allComments.partition(by: { $0.parentID != nil })
+        let children = allComments[childrenStartIndex...]
+
+        var childrenByID = [Comment.ID: [Comment.ID]]()
+        children.forEach
+        { child in
+            guard let parentID = child.parentID else
+            {
+                return
+            }
+
+            childrenByID[parentID] = (childrenByID[parentID] ?? []) + [child.id]
+        }
+
+        let identifiedComments = Dictionary(uniqueKeysWithValues: allComments.lazy.map { ($0.id, $0) })
+
+        /// Recursively populates child comments by looking up IDs from `childrenByID`
+        func populateChildren(_ comment: Comment) -> Comment
         {
-            print("Older API spec")
-            
-            for comment in commentArray
+            guard let childIDs = childrenByID[comment.id] else
             {
-                let newComment: Comment = Comment(
-                    id: comment["id"].intValue,
-                    postID: comment["post_id"].intValue,
-                    creatorID: comment["creator_id"].intValue,
-                    //postName: comment["post_name"].stringValue,
-                    parentID: comment["parent_id"].int,
-                    content: comment["content"].stringValue,
-                    removed: comment["removed"].boolValue,
-                    //read: comment["read"].boolValue,
-                    published: comment["published"].stringValue,
-                    deleted: comment["deleted"].boolValue,
-                    updated: comment["updated"].string,
-                    apID: comment["ap_id"].url!,
-                    local: comment["local"].boolValue,
-                    communityID: comment["community_id"].intValue,
-                    communityActorID: comment["community_actor_id"].url!,
-                    communityLocal: comment["local"].boolValue,
-                    communityName: comment["community_name"].stringValue,
-                    communityIcon: comment["community_icon"].url,
-                    communityHideFromAll: comment["community_hide_from_all"].boolValue,
-                    //bannedFromCommunity: comment["banned_from_community"].boolValue,
-                    creatorPublished: comment["creator_published"].stringValue,
-                    score: comment["score"].intValue,
-                    upvotes: comment["upvotes"].intValue,
-                    downvotes: comment["downvotes"].intValue,
-                    //hotRank: comment["hot_rank"].intValue,
-                    //hotRankActive: comment["hot_rank_active"].intValue,
-                    saved: comment["saved"].boolValue,
-                    author: User(
-                        id: 0,
-                        name: comment["creator_name"].stringValue,
-                        displayName: comment["creator_preferred_username"].stringValue,
-                        avatarLink: comment["creator_avatar"].url,
-                        bannerLink: nil,
-                        inboxLink: nil,
-                        bio: nil,
-                        banned: comment["banned"].boolValue,
-                        actorID: comment["creator_actor_id"].url!,
-                        local: comment["creator_local"].boolValue,
-                        deleted: false,
-                        admin: false,
-                        bot: false,
-                        onInstanceID: 0
-                    ),
-                    childCount: nil,
-                    //subscribed: comment["subscribed"].boolValue,
-                    children: .init()
-                )
-                
-                print("New comment: \(newComment)")
-                
-                commentTracker.insert(
-                    newComment
-                )
+                return comment
             }
-        }
-        else
-        {
-            print("Newer API spec")
-            
-            for comment in commentArray
-            {
-                let newComment: Comment = Comment(
-                    id: comment["comment", "id"].intValue,
-                    postID: comment["post", "id"].intValue,
-                    creatorID: comment["comment", "creator_id"].intValue,
-                    //postName: <#T##String#>,
-                    parentID: {
-                        let stringRepresentationOfPath: String = comment["comment", "path"].stringValue
-                        let componentsOfPath = stringRepresentationOfPath.components(separatedBy: ".")
-                        
-                        if componentsOfPath.count == 2 /// If there are two elements, it'ß the root (0) and the comment itself. That means there is no parent and parentID should be nil
-                        {
-                            return nil
-                        }
-                        else
-                        {
-                            return Int(componentsOfPath.last!)
-                        }
-                    }(),
-                    content: comment["comment", "content"].stringValue,
-                    removed: comment["comment", "removed"].boolValue,
-                    //read: comment[""],
-                    published: comment["comment", "published"].stringValue,
-                    deleted: comment["comment", "deleted"].boolValue,
-                    updated: comment["comment", "updated"].string,
-                    apID: comment["comment", "ap_id"].url!,
-                    local: comment["comment", "local"].boolValue,
-                    communityID: comment["community", "id"].intValue,
-                    communityActorID: comment["community", "actor_id"].url!,
-                    communityLocal: comment["community", "local"].boolValue,
-                    communityName: comment["community", "name"].stringValue,
-                    communityIcon: comment["community", "icon"].url,
-                    communityHideFromAll: comment["community", "hidden"].boolValue,
-                    creatorPublished: comment["creator", "published"].stringValue,
-                    score: comment["counts", "score"].intValue,
-                    upvotes: comment["counts", "upvotes"].intValue,
-                    downvotes: comment["counts", "downvotes"].intValue,
-                    //hotRank: <#T##Int#>,
-                    //hotRankActive: <#T##Int?#>,
-                    saved: comment["saved"].boolValue,
-                    author: User(
-                        id: comment["creator", "id"].intValue,
-                        name: comment["creator", "name"].stringValue,
-                        displayName: comment["creator", "display_name"].string,
-                        avatarLink: comment["creator", "avatar"].url,
-                        bannerLink: comment["creator", "banner"].url,
-                        inboxLink: comment["creator", "inbox_url"].url,
-                        bio: comment["creator", "bio"].stringValue,
-                        banned: comment["creator", "banned"].boolValue,
-                        actorID: comment["creator", "actor_id"].url!,
-                        local: comment["creator", "local"].boolValue,
-                        deleted: comment["creator", "deleted"].boolValue,
-                        admin: comment["creator", "admin"].boolValue,
-                        bot: comment["creator", "bot_account"].boolValue,
-                        onInstanceID: comment["creator", "instance_id"].intValue
-                    ),
-                    //subscribed: <#T##Bool?#>,
-                    childCount: comment["counts", "child_count"].int
-                )
-                
-                print("New comment: \(newComment)")
-                
-                commentTracker.insert(
-                    newComment
-                )
+
+            var commentWithChildren = comment
+            commentWithChildren.children = childIDs.compactMap
+            { id in
+                guard let child = identifiedComments[id] else
+                {
+                    return nil
+                }
+                return populateChildren(child)
             }
+            return commentWithChildren
         }
-                
-        print("Comment set: \(commentTracker)")
-        
-        let topLevelComments: [Comment] = commentTracker.filter({ $0.parentID == nil }) /// First, get all the comments with no parentID. Those will be the root of all other comments
-        for topLevelComment in topLevelComments {
-            commentTracker.remove(topLevelComment) /// Remove all the top level comments from the initial set
-        }
-        
-        var finalComments: [Comment] = topLevelComments /// Create a final array of all the comments. Here, set it to all the top-level comments
-        
-        print("Found these parent comments \(finalComments.count): \(finalComments)")
-        
-        while !commentTracker.isEmpty
-        { /// These comments should have a parentID
-            for comment in finalComments
-            {
-                
-                let matchedComment: Comment = finalComments.filter({ $0.id == comment.id }).first!
-                let indiceOfMatchedComment: Int = finalComments.firstIndex(of: matchedComment)!
-                
-                print("Matched this comment: \(matchedComment)")
-                
-                print("Found indice of matched comment: \(indiceOfMatchedComment)")
-                
-                finalComments[indiceOfMatchedComment].children?.append(matchedComment)
-                
-                commentTracker.remove(matchedComment)
-            }
-        }
-        
-        return finalComments
+
+        let parents = allComments[..<childrenStartIndex]
+        return parents.map(populateChildren)
     }
     catch let parsingError
     {
@@ -191,3 +64,118 @@ func parseComments(commentResponse: String, instanceLink: URL) async throws -> [
     }
 }
 
+private extension JSON {
+
+    func v1ToComment() -> Comment {
+        Comment(
+            id: self["id"].intValue,
+            postID: self["post_id"].intValue,
+            creatorID: self["creator_id"].intValue,
+            //postName: self["post_name"].stringValue,
+            parentID: self["parent_id"].int,
+            content: self["content"].stringValue,
+            removed: self["removed"].boolValue,
+            //read: self["read"].boolValue,
+            published: self["published"].stringValue,
+            deleted: self["deleted"].boolValue,
+            updated: self["updated"].string,
+            apID: self["ap_id"].url!,
+            local: self["local"].boolValue,
+            communityID: self["community_id"].intValue,
+            communityActorID: self["community_actor_id"].url!,
+            communityLocal: self["local"].boolValue,
+            communityName: self["community_name"].stringValue,
+            communityIcon: self["community_icon"].url,
+            communityHideFromAll: self["community_hide_from_all"].boolValue,
+            //bannedFromCommunity: self["banned_from_community"].boolValue,
+            creatorPublished: self["creator_published"].stringValue,
+            score: self["score"].intValue,
+            upvotes: self["upvotes"].intValue,
+            downvotes: self["downvotes"].intValue,
+            //hotRank: self["hot_rank"].intValue,
+            //hotRankActive: self["hot_rank_active"].intValue,
+            saved: self["saved"].boolValue,
+            author: User(
+                id: 0,
+                name: self["creator_name"].stringValue,
+                displayName: self["creator_preferred_username"].stringValue,
+                avatarLink: self["creator_avatar"].url,
+                bannerLink: nil,
+                inboxLink: nil,
+                bio: nil,
+                banned: self["banned"].boolValue,
+                actorID: self["creator_actor_id"].url!,
+                local: self["creator_local"].boolValue,
+                deleted: false,
+                admin: false,
+                bot: false,
+                onInstanceID: 0
+            ),
+            childCount: nil,
+            //subscribed: comment["subscribed"].boolValue,
+            children: .init()
+        )
+    }
+
+    func v2ToComment() -> Comment {
+        Comment(
+            id: self["comment", "id"].intValue,
+            postID: self["post", "id"].intValue,
+            creatorID: self["comment", "creator_id"].intValue,
+            //postName: <#T##String#>,
+            parentID: {
+                let stringRepresentationOfPath: String = self["comment", "path"].stringValue
+                let componentsOfPath = stringRepresentationOfPath.components(separatedBy: ".")
+
+                if componentsOfPath.count == 2 /// If there are two elements, it'ß the root (0) and the comment itself. That means there is no parent and parentID should be nil
+                {
+                    return nil
+                }
+                else
+                {
+                    return Int(componentsOfPath.dropLast(1).last!)
+                }
+            }(),
+            content: self["comment", "content"].stringValue,
+            removed: self["comment", "removed"].boolValue,
+            //read: self[""],
+            published: self["comment", "published"].stringValue,
+            deleted: self["comment", "deleted"].boolValue,
+            updated: self["comment", "updated"].string,
+            apID: self["comment", "ap_id"].url!,
+            local: self["comment", "local"].boolValue,
+            communityID: self["community", "id"].intValue,
+            communityActorID: self["community", "actor_id"].url!,
+            communityLocal: self["community", "local"].boolValue,
+            communityName: self["community", "name"].stringValue,
+            communityIcon: self["community", "icon"].url,
+            communityHideFromAll: self["community", "hidden"].boolValue,
+            creatorPublished: self["creator", "published"].stringValue,
+            score: self["counts", "score"].intValue,
+            upvotes: self["counts", "upvotes"].intValue,
+            downvotes: self["counts", "downvotes"].intValue,
+            //hotRank: <#T##Int#>,
+            //hotRankActive: <#T##Int?#>,
+            saved: self["saved"].boolValue,
+            author: User(
+                id: self["creator", "id"].intValue,
+                name: self["creator", "name"].stringValue,
+                displayName: self["creator", "display_name"].string,
+                avatarLink: self["creator", "avatar"].url,
+                bannerLink: self["creator", "banner"].url,
+                inboxLink: self["creator", "inbox_url"].url,
+                bio: self["creator", "bio"].stringValue,
+                banned: self["creator", "banned"].boolValue,
+                actorID: self["creator", "actor_id"].url!,
+                local: self["creator", "local"].boolValue,
+                deleted: self["creator", "deleted"].boolValue,
+                admin: self["creator", "admin"].boolValue,
+                bot: self["creator", "bot_account"].boolValue,
+                onInstanceID: self["creator", "instance_id"].intValue
+            ),
+            //subscribed: <#T##Bool?#>,
+            childCount: self["counts", "child_count"].int,
+            children: []
+        )
+    }
+}

--- a/Mlem/Models/User-Interactable/Comment.swift
+++ b/Mlem/Models/User-Interactable/Comment.swift
@@ -49,5 +49,5 @@ struct Comment: Codable, Identifiable, Hashable
     let author: User
 
     let childCount: Int?
-    var children: [Comment]?
+    var children: [Comment]
 }


### PR DESCRIPTION
**Background**

First pass at an algorithm to turn a 'flat' array of comments into an array of threaded/nested comments, where a `children` array is populated for parents with child comments. There's probably more efficient/tidy ways of implementing this though. Note that the UI to actually show threaded comments still needs to be implemented separately!

The diff is best viewed split rather than unified.

**Implementation**
Steps:
1. Sort comments into parents first, followed by children (comments that have a parent ID)
2. For each child, add it to an array keyed under its parent's ID
4. For each parent:
    4a. Recursively lookup the IDs of its children from the dictionary populated in step 2 (which has now saved us from looping through every comment in the original array to find a match by ID)
    4b. Turn each ID into an actual child comment object