### PR TITLE
Commons Clause is not Open Source but Source Available 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ As of now, Mlem is still in beta. While it already has many core features, there
 
 Mlem is licensed under [Commons Clause](https://commonsclause.com).
 
-This means that Mlem is open-source and you can do whatever you want with its source, like modifying it, contributing to it etc., but you can't sell Mlem or modified versions of it.
+This means that Mlem is source available and you can do whatever you want with its source, like modifying it, contributing to it etc., but you can't sell Mlem or modified versions of it.


### PR DESCRIPTION
# Checklist
- [x] I have described what this PR contains

**Choose one of the following two options:**
- [x] This PR does not introduce major changes
- [ ] This PR introduces major changes, and I have consulted the *Mlem Development Matrix room*

**Choose one of the following two options:**
- [x] This PR does not change the UI in any way
- [ ] This PR adds new UI elements / changes the UI, and I have attached pictures or videos of the new / changed UI elements

# Pull Request Information

## About this Pull Request
Remove the word open-source from the readme as the Commons Clause denies the 1st and 3rd rule in the Open Source Definition (which is published by the OSI)

## Additional Context

The Open Source Definition: https://opensource.org/osd/
FSF: https://www.gnu.org/licenses/license-list.html#comclause
Wikipedia definition: https://en.wikipedia.org/wiki/Source-available_software#Commons_Clause

- [ ] 1. Also the `LICENSE` file is using the GPLv3.0 text first!
This ensures that Github considers this project to be licensed under the GPLv3.0, please move the Commons Clause text to the beginning so that Github reads that first. 
- [ ] 2. There is a `gpl-3.0.txt` I advise this to be removed as this just create confusion under what license this software is under and the text for the GPL license is already in the LICENSE file.