### PR TITLE
Fixed subscribed communities being limited to one page

### DIFF
--- a/Mlem/API/Requests/Community/ListCommunities.swift
+++ b/Mlem/API/Requests/Community/ListCommunities.swift
@@ -28,9 +28,8 @@ struct ListCommunitiesRequest: APIGetRequest {
         self.instanceURL = account.instanceLink
         self.queryItems = [
             .init(name: "sort", value: sort?.rawValue),
-
-            .init(name: "limit", value: limit.map(String.init)),
-            .init(name: "page", value: page.map(String.init)),
+            .init(name: "limit", value: limit?.description),
+            .init(name: "page", value: page?.description),
             .init(name: "type_", value: type.rawValue),
 
             .init(name: "auth", value: account.accessToken),

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
@@ -104,7 +104,7 @@ struct CommunityListView: View
     }
     
     private func refreshCommunitiesList() async {
-        let communitiesRequestCount = 25
+        let communitiesRequestCount = 50
         do {
             var moreCommunities = true
             var refreshedCommunities: [APICommunity] = []

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community List View/Community List View.swift
@@ -71,24 +71,14 @@ struct CommunityListView: View
                 }
             }
         }
+        .refreshable {
+            await refreshCommunitiesList()
+        }
         .task(priority: .userInitiated) {
             // NOTE: This will not auto request if data is provided
             // This is normally only during preview
             if hasTestCommunities == false {
-                let request = ListCommunitiesRequest(account: account, sort: nil, page: nil, limit: nil, type: FeedType.subscribed);
-                do {
-                    let response = try await APIClient().perform(request: request);
-                    
-                    let newSubscribedCommunities = response.communities.map({
-                        return $0.community;
-                    }).sorted(by: {
-                        $0.name < $1.name
-                    });
-                    
-                    subscribedCommunities = newSubscribedCommunities.sorted(by: { $0.name < $1.name })
-                } catch {
-                    // TODO: Some sort of common alert banner?
-                }
+                await refreshCommunitiesList()
             }
             
         }.onAppear {
@@ -110,6 +100,37 @@ struct CommunityListView: View
                                                                                                          sidebarLabel: "#",
                                                                                                          sidebarIcon: nil),
                                inlineHeaderLabel: "#") ]
+        }
+    }
+    
+    private func refreshCommunitiesList() async {
+        let communitiesRequestCount = 25
+        do {
+            var moreCommunities = true
+            var refreshedCommunities: [APICommunity] = []
+            var communitiesPage = 1
+            repeat {
+                let request = ListCommunitiesRequest(account: account, sort: nil, page: communitiesPage, limit: communitiesRequestCount, type: FeedType.subscribed);
+                
+                let response = try await APIClient().perform(request: request);
+                
+                let newSubscribedCommunities = response.communities.map({
+                    return $0.community;
+                }).sorted(by: {
+                    $0.name < $1.name
+                });
+                
+                refreshedCommunities.append(contentsOf: newSubscribedCommunities)
+                
+                communitiesPage = communitiesPage + 1
+                
+                // Go until we get less than the count we ask for
+                moreCommunities = response.communities.count == communitiesRequestCount
+            } while (moreCommunities)
+            
+            subscribedCommunities = refreshedCommunities.sorted(by: { $0.name < $1.name })
+        } catch {
+            print("Failed to refresh communities: \(error)")
         }
     }
     


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have described what this PR contains

**Choose one of the following two options:**
- - [x] This PR does not introduce major changes
- - [ ] This PR introduces major changes, and I have consulted the *Mlem Development Matrix room*

**Choose one of the following two options:**
- - [x] This PR does not change the UI in any way
- - [ ] This PR adds new UI elements / changes the UI, and I have attached pictures or videos of the new / changed UI elements

# Pull Request Information

## About this Pull Request
We were not paging communities so we were being limited to a single page of how ever many the server decided to send us.

## Screenshots and Videos
n/a

## Additional Context
Fixes #265 #242 
