### PR TITLE
Fixed:  Favorited communities occasionally show up multiple times #324

### DIFF
--- a/Mlem/API/Models/Community/APICommunity.swift
+++ b/Mlem/API/Models/Community/APICommunity.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // lemmy_db_schema::source::community::CommunitySafe
-struct APICommunity: Codable, Identifiable, Hashable {
+struct APICommunity: Codable, Identifiable {
     let id: Int
     let name: String
     let title: String
@@ -27,8 +27,12 @@ struct APICommunity: Codable, Identifiable, Hashable {
     let instanceId: Int
 }
 
-extension APICommunity: Equatable {
+extension APICommunity: Equatable, Hashable {
     static func == (lhs: APICommunity, rhs: APICommunity) -> Bool {
         lhs.id == rhs.id
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.id)
     }
 }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read CONTRIBUTING.txt
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #324 
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
It seems like what ever default hasher was created for `APICommunity` used some fields that change over time causing the same community to hash differently, thus duplicate.

An explicit hash which only uses the community ID fixes it.

## Screenshots and Videos
n/a

## Additional Context
n/a
