### PR TITLE
fix #390 - ensure stable id is used for posts in tracker

### DIFF
--- a/Mlem/API/Models/Posts/APIPostView.swift
+++ b/Mlem/API/Models/Posts/APIPostView.swift
@@ -45,6 +45,6 @@ extension APIPostView: Hashable {
 // MARK: - FeedTrackerItem
 
 extension APIPostView: FeedTrackerItem {
-    var uniqueIdentifier: some Hashable { id }
+    var uniqueIdentifier: some Hashable { post.id }
     var published: Date { post.published }
 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #390
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR addresses the issue described in #390

As the `update(...)` function in the tracker requires a stable identifier it has been changed to use the posts `id` instead of the hashed value used by the UI.
