### PR TITLE
Added moderator button to profile to show moderated communities (fixes #335)

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		6D8F08FF2A4029AE003EB4FD /* Community List View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D8F08FE2A4029AE003EB4FD /* Community List View.swift */; };
 		6D91D4552A415994006B8F9A /* CommunityListSidebarEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D91D4542A415994006B8F9A /* CommunityListSidebarEntry.swift */; };
 		6D91D4582A4159D8006B8F9A /* CommunityListRowViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D91D4572A4159D8006B8F9A /* CommunityListRowViews.swift */; };
+		6DA7E9A22A50764E0095AB68 /* UserViewTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA7E9A12A50764E0095AB68 /* UserViewTab.swift */; };
 		6DE118392A4A20D600810C7E /* Lazy Load Post Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE118382A4A20D600810C7E /* Lazy Load Post Link.swift */; };
 		6DE1183C2A4A217400810C7E /* Profile View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE1183B2A4A217400810C7E /* Profile View.swift */; };
 		6DE1183E2A4A4FF500810C7E /* Delete Post or Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE1183D2A4A4FF500810C7E /* Delete Post or Comment.swift */; };
@@ -430,6 +431,7 @@
 		6D8F08FE2A4029AE003EB4FD /* Community List View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Community List View.swift"; sourceTree = "<group>"; };
 		6D91D4542A415994006B8F9A /* CommunityListSidebarEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityListSidebarEntry.swift; sourceTree = "<group>"; };
 		6D91D4572A4159D8006B8F9A /* CommunityListRowViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityListRowViews.swift; sourceTree = "<group>"; };
+		6DA7E9A12A50764E0095AB68 /* UserViewTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserViewTab.swift; sourceTree = "<group>"; };
 		6DE118382A4A20D600810C7E /* Lazy Load Post Link.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Lazy Load Post Link.swift"; sourceTree = "<group>"; };
 		6DE1183B2A4A217400810C7E /* Profile View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Profile View.swift"; sourceTree = "<group>"; };
 		6DE1183D2A4A4FF500810C7E /* Delete Post or Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Delete Post or Comment.swift"; sourceTree = "<group>"; };
@@ -1163,6 +1165,7 @@
 		63F0C7A02A05198600A18C5D /* Enums */ = {
 			isa = PBXGroup;
 			children = (
+				6DA7E9A02A50763B0095AB68 /* User */,
 				CD64832B2A38CE4200EE6CA3 /* Settings */,
 				63344C592A080688001BC616 /* Errors */,
 				6317ABCA2A37292700603D76 /* FeedType.swift */,
@@ -1201,6 +1204,14 @@
 				6D91D4572A4159D8006B8F9A /* CommunityListRowViews.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		6DA7E9A02A50763B0095AB68 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				6DA7E9A12A50764E0095AB68 /* UserViewTab.swift */,
+			);
+			path = User;
 			sourceTree = "<group>";
 		};
 		6DE1183A2A4A215F00810C7E /* Profile */ = {
@@ -1532,6 +1543,7 @@
 				CDF842662A49F61100723DA0 /* InboxTabs.swift in Sources */,
 				CD525F652A4B6D8F00BCA794 /* Community Link View.swift in Sources */,
 				637218592A3A2AAD008C4816 /* APISiteAggregates.swift in Sources */,
+				6DA7E9A22A50764E0095AB68 /* UserViewTab.swift in Sources */,
 				637218772A3A2AAD008C4816 /* APIRequest.swift in Sources */,
 				63A09B69285F53E9004F0032 /* Error View.swift in Sources */,
 				CD3FBCE72A4A8CE300B2063F /* Messages Feed View.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -179,6 +179,8 @@
 		6DE118392A4A20D600810C7E /* Lazy Load Post Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE118382A4A20D600810C7E /* Lazy Load Post Link.swift */; };
 		6DE1183C2A4A217400810C7E /* Profile View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE1183B2A4A217400810C7E /* Profile View.swift */; };
 		6DE1183E2A4A4FF500810C7E /* Delete Post or Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE1183D2A4A4FF500810C7E /* Delete Post or Comment.swift */; };
+		6DEB0FFB2A4F87BF007CAB99 /* User Moderator View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEB0FFA2A4F87BF007CAB99 /* User Moderator View.swift */; };
+		6DEB0FFD2A4F891B007CAB99 /* User Moderator Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */; };
 		6DFF50432A48DED3001E648D /* Inbox View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFF50422A48DED3001E648D /* Inbox View.swift */; };
 		6DFF50452A48E373001E648D /* GetPrivateMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DFF50442A48E373001E648D /* GetPrivateMessages.swift */; };
 		B11D72832A49FAA7009DC22F /* Cached Image With Nsfw Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11D72822A49FAA7009DC22F /* Cached Image With Nsfw Filter.swift */; };
@@ -431,6 +433,8 @@
 		6DE118382A4A20D600810C7E /* Lazy Load Post Link.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Lazy Load Post Link.swift"; sourceTree = "<group>"; };
 		6DE1183B2A4A217400810C7E /* Profile View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Profile View.swift"; sourceTree = "<group>"; };
 		6DE1183D2A4A4FF500810C7E /* Delete Post or Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Delete Post or Comment.swift"; sourceTree = "<group>"; };
+		6DEB0FFA2A4F87BF007CAB99 /* User Moderator View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User Moderator View.swift"; sourceTree = "<group>"; };
+		6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User Moderator Link.swift"; sourceTree = "<group>"; };
 		6DFF50422A48DED3001E648D /* Inbox View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox View.swift"; sourceTree = "<group>"; };
 		6DFF50442A48E373001E648D /* GetPrivateMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPrivateMessages.swift; sourceTree = "<group>"; };
 		B11D72822A49FAA7009DC22F /* Cached Image With Nsfw Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cached Image With Nsfw Filter.swift"; sourceTree = "<group>"; };
@@ -1204,6 +1208,7 @@
 			children = (
 				6DE1183B2A4A217400810C7E /* Profile View.swift */,
 				63ABCE0D27F894060047A7D0 /* User View.swift */,
+				6DEB0FFA2A4F87BF007CAB99 /* User Moderator View.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -1224,6 +1229,7 @@
 				B14E93BF2A45CA3400D6DA93 /* Post Link.swift */,
 				B14E93C12A45D3B300D6DA93 /* Community Link.swift */,
 				6DE118382A4A20D600810C7E /* Lazy Load Post Link.swift */,
+				6DEB0FFC2A4F891B007CAB99 /* User Moderator Link.swift */,
 			);
 			path = "Navigation Contexts";
 			sourceTree = "<group>";
@@ -1497,6 +1503,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DEB0FFB2A4F87BF007CAB99 /* User Moderator View.swift in Sources */,
 				63D64E052A1BC20D00FD39C6 /* Post Post.swift in Sources */,
 				63F0C7A82A0522FC00A18C5D /* Saved Account Tracker.swift in Sources */,
 				6372186A2A3A2AAD008C4816 /* GetComment.swift in Sources */,
@@ -1601,6 +1608,7 @@
 				CDF8426B2A4A2AB600723DA0 /* Inbox Item.swift in Sources */,
 				637218572A3A2AAD008C4816 /* APISiteView.swift in Sources */,
 				B14E93C02A45CA3400D6DA93 /* Post Link.swift in Sources */,
+				6DEB0FFD2A4F891B007CAB99 /* User Moderator Link.swift in Sources */,
 				63AF452D2A2F37EB00E0266F /* Own Account Tracker.swift in Sources */,
 				6D405AFF2A43E66600C65F9C /* User Profile Label.swift in Sources */,
 				63344C562A07D81D001BC616 /* Array - Prepend.swift in Sources */,

--- a/Mlem/Enums/User/UserViewTab.swift
+++ b/Mlem/Enums/User/UserViewTab.swift
@@ -1,0 +1,22 @@
+//
+//  UserViewTab.swift
+//  Mlem
+//
+//  Created by Jake Shirley on 7/1/23.
+//
+
+import Foundation
+
+enum UserViewTab: String, CaseIterable, Identifiable {
+    case overview, comments, posts, saved
+
+    var id: Self { self }
+    
+    var label: String {
+        return self.rawValue.capitalized
+    }
+    
+    var onlyShowInOwnProfile: Bool {
+        return self == UserViewTab.saved
+    }
+}

--- a/Mlem/Extensions/View - Handle Lemmy Links.swift
+++ b/Mlem/Extensions/View - Handle Lemmy Links.swift
@@ -87,6 +87,13 @@ struct HandleLemmyLinksDisplay: ViewModifier {
                     Text("You must be signed in to view this user")
                 }
             }
+            .navigationDestination(for: UserModeratorLink.self) { user in
+                if let account = account {
+                    UserModeratorView(account: account, userDetails: user.user, moderatedCommunities: user.moderatedCommunities)
+                } else {
+                    Text("You must be signed in to view this user")
+                }
+            }
     }
     // swiftlint:enable function_body_length
 }

--- a/Mlem/Models/Navigation Contexts/User Moderator Link.swift
+++ b/Mlem/Models/Navigation Contexts/User Moderator Link.swift
@@ -1,0 +1,24 @@
+//
+//  Moderator User Link.swift
+//  Mlem
+//
+//  Created by Jake Shirley on 6/30/23.
+//
+
+import Foundation
+import SwiftUI
+
+struct UserModeratorLink: Equatable, Identifiable, Hashable {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.id)
+    }
+
+    var id: Int { user.person.id }
+
+    let user: APIPersonView
+    let moderatedCommunities: [APICommunityModeratorView]
+}

--- a/Mlem/Views/Tabs/Profile/User Moderator View.swift
+++ b/Mlem/Views/Tabs/Profile/User Moderator View.swift
@@ -20,10 +20,8 @@ struct UserModeratorView: View {
     var body: some View {
         List {
             ForEach(moderatedCommunities) { community in
-                HStack {
-                    CommunityLinkView(community: community.community)
-                    Spacer()
-                }
+                CommunityLinkView(community: community.community)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .navigationTitle("Moderator Details")

--- a/Mlem/Views/Tabs/Profile/User Moderator View.swift
+++ b/Mlem/Views/Tabs/Profile/User Moderator View.swift
@@ -8,11 +8,14 @@
 import CachedAsyncImage
 import SwiftUI
 
+/*
+ A view that displays the list of communities a user moderates
+ */
 struct UserModeratorView: View {
     // parameters
     let account: SavedAccount
-    @State var userDetails: APIPersonView
-    @State var moderatedCommunities: [APICommunityModeratorView]
+    var userDetails: APIPersonView
+    var moderatedCommunities: [APICommunityModeratorView]
     
     var body: some View {
         List {

--- a/Mlem/Views/Tabs/Profile/User Moderator View.swift
+++ b/Mlem/Views/Tabs/Profile/User Moderator View.swift
@@ -1,0 +1,31 @@
+//
+//  User Moderator View.swift
+//  Mlem
+//
+//  Created by Jake Shirley on 6/30/23.
+//
+
+import CachedAsyncImage
+import SwiftUI
+
+struct UserModeratorView: View {
+    // parameters
+    let account: SavedAccount
+    @State var userDetails: APIPersonView
+    @State var moderatedCommunities: [APICommunityModeratorView]
+    
+    var body: some View {
+        List {
+            ForEach(moderatedCommunities) { community in
+                HStack {
+                    CommunityLinkView(community: community.community)
+                    Spacer()
+                }
+            }
+        }
+        .navigationTitle("Moderator Details")
+        .navigationBarTitleDisplayMode(.inline)
+        .headerProminence(.standard)
+        .listStyle(.plain)
+    }
+}

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -34,7 +34,6 @@ struct UserView: View {
     @State private var avatarSubtext: String = ""
     @State private var showingCakeDay = false
     @State private var moderatedCommunities: [APICommunityModeratorView] = []
-    @State private var isUserBlocked = false
     
     @State private var selectionSection = 0
     @State var isDragging: Bool = false
@@ -149,26 +148,6 @@ struct UserView: View {
         } else {
             avatarSubtext = ""
         }
-    }
-    
-    // Tries to deduce blocked state from posts
-    // because there is no direct way to see if we are blocking someone
-    private func updatedBlockedState() {
-        var isBlocked = false
-        
-        for post in privatePostTracker.items where post.creatorBlocked {
-            isBlocked = true
-            break
-        }
-        
-        if !isBlocked {
-            for comment in privateCommentTracker.comments where comment.commentView.creatorBlocked {
-                isBlocked = true
-                break
-            }
-        }
-        
-        isUserBlocked = isBlocked
     }
     
     private func toggleCakeDayVisible() {
@@ -358,7 +337,6 @@ struct UserView: View {
             userDetails = authoredContent.personView
             moderatedCommunities = authoredContent.moderates
             updateAvatarSubtext()
-            updatedBlockedState()
         } catch {
             handle(error)
         }

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -32,20 +32,13 @@ struct UserView: View {
     @StateObject private var privatePostTracker: PostTracker = .init(shouldPerformMergeSorting: false)
     @StateObject private var privateCommentTracker: CommentTracker = .init()
     @State private var avatarSubtext: String = ""
-    @State var showingCakeDay = false
+    @State private var showingCakeDay = false
+    @State private var moderatedCommunities: [APICommunityModeratorView] = []
+    @State private var isUserBlocked = false
     
     @State private var selectionSection = 0
     @State var isDragging: Bool = false
     @FocusState var isReplyFieldFocused
-    
-    enum FeedType: String, CaseIterable, Identifiable {
-        case overview = "Overview"
-        case comments = "Comments"
-        case posts = "Posts"
-        case saved = "Saved"
-        
-        var id: String { return self.rawValue }
-    }
     
     struct FeedItem: Identifiable {
         let id = UUID()
@@ -69,34 +62,55 @@ struct UserView: View {
             progressView
         }
     }
+    
+    @ViewBuilder
+    private var moderatorButton: some View {
+        if let user = userDetails {
+            if !moderatedCommunities.isEmpty {
+                NavigationLink(value: UserModeratorLink(user: user, moderatedCommunities: moderatedCommunities)) {
+                    Image(systemName: "shield.fill")
+                        .resizable()
+                        .foregroundColor(.green)
+                        .padding(2)
+                        .background(Image(systemName: "shield")
+                            .resizable()
+                            .foregroundColor(Color(UIColor.label))
+                        )
+                }
+            }
+        }
+    }
 
+    private func header(for userDetails: APIPersonView) -> some View {
+        CommunitySidebarHeader(
+            title: userDetails.person.displayName ?? userDetails.person.name,
+            subtitle: "@\(userDetails.person.name)@\(userDetails.person.actorId.host()!)",
+            avatarSubtext: $avatarSubtext,
+            avatarSubtextClicked: self.toggleCakeDayVisible,
+            bannerURL: shouldShowUserHeaders ? userDetails.person.banner : nil,
+            avatarUrl: userDetails.person.avatar,
+            label1: "\(userDetails.counts.commentCount) Comments",
+            label2: "\(userDetails.counts.postCount) Posts")
+    }
+    
     private func view(for userDetails: APIPersonView) -> some View {
         ScrollView {
-            CommunitySidebarHeader(
-                title: userDetails.person.displayName ?? userDetails.person.name,
-                subtitle: "@\(userDetails.person.name)@\(userDetails.person.actorId.host()!)",
-                avatarSubtext: $avatarSubtext,
-                avatarSubtextClicked: self.toggleCakeDayVisible,
-                bannerURL: shouldShowUserHeaders ? userDetails.person.banner : nil,
-                avatarUrl: userDetails.person.avatar,
-                label1: "\(userDetails.counts.commentCount) Comments",
-                label2: "\(userDetails.counts.postCount) Posts")
+            header(for: userDetails)
             
             if let bio = userDetails.person.bio {
                 MarkdownView(text: bio, isNsfw: false).padding()
             }
             
             Picker(selection: $selectionSection, label: Text("Profile Section")) {
-                Text(FeedType.overview.rawValue).tag(0)
-                Text(FeedType.comments.rawValue).tag(1)
-                Text(FeedType.posts.rawValue).tag(2)
+                Text("Overview").tag(0)
+                Text("Comments").tag(1)
+                Text("Posts").tag(2)
                 
                 // Only show saved posts if we are
                 // browsing our own profile
                 if isShowingOwnProfile() {
-                    Text(FeedType.saved.rawValue).tag(3)
+                    Text("Saved").tag(3)
                 }
-                
             }
             .pickerStyle(.segmented)
             .padding(.horizontal)
@@ -122,6 +136,10 @@ struct UserView: View {
         .headerProminence(.standard)
         .refreshable {
             await tryLoadUser()
+        }.toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                moderatorButton
+            }
         }
     }
     
@@ -138,6 +156,26 @@ struct UserView: View {
         } else {
             avatarSubtext = ""
         }
+    }
+    
+    // Tries to deduce blocked state from posts
+    // because there is no direct way to see if we are blocking someone
+    private func updatedBlockedState() {
+        var isBlocked = false
+        
+        for post in privatePostTracker.items where post.creatorBlocked {
+            isBlocked = true
+            break
+        }
+        
+        if !isBlocked {
+            for comment in privateCommentTracker.comments where comment.commentView.creatorBlocked {
+                isBlocked = true
+                break
+            }
+        }
+        
+        isUserBlocked = isBlocked
     }
     
     private func toggleCakeDayVisible() {
@@ -325,7 +363,9 @@ struct UserView: View {
             }
             
             userDetails = authoredContent.personView
+            moderatedCommunities = authoredContent.moderates
             updateAvatarSubtext()
+            updatedBlockedState()
         } catch {
             handle(error)
         }

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -35,7 +35,7 @@ struct UserView: View {
     @State private var showingCakeDay = false
     @State private var moderatedCommunities: [APICommunityModeratorView] = []
     
-    @State private var selectionSection = 0
+    @State private var selectionSection = UserViewTab.overview
     @State var isDragging: Bool = false
     @FocusState var isReplyFieldFocused
     
@@ -64,11 +64,9 @@ struct UserView: View {
     
     @ViewBuilder
     private var moderatorButton: some View {
-        if let user = userDetails {
-            if !moderatedCommunities.isEmpty {
-                NavigationLink(value: UserModeratorLink(user: user, moderatedCommunities: moderatedCommunities)) {
-                    Image(systemName: "shield")
-                }
+        if let user = userDetails, !moderatedCommunities.isEmpty {
+            NavigationLink(value: UserModeratorLink(user: user, moderatedCommunities: moderatedCommunities)) {
+                Image(systemName: "shield")
             }
         }
     }
@@ -94,30 +92,29 @@ struct UserView: View {
             }
             
             Picker(selection: $selectionSection, label: Text("Profile Section")) {
-                Text("Overview").tag(0)
-                Text("Comments").tag(1)
-                Text("Posts").tag(2)
-                
-                // Only show saved posts if we are
-                // browsing our own profile
-                if isShowingOwnProfile() {
-                    Text("Saved").tag(3)
+                ForEach(UserViewTab.allCases, id: \.id) { tab in
+                    // Skip tabs that are meant for only our profile
+                    if tab.onlyShowInOwnProfile {
+                        if isShowingOwnProfile() {
+                            Text(tab.label).tag(tab.rawValue)
+                        }
+                    } else {
+                        Text(tab.label).tag(tab.rawValue)
+                    }
                 }
             }
             .pickerStyle(.segmented)
             .padding(.horizontal)
             
             switch selectionSection {
-            case 0:
+            case UserViewTab.overview:
                 mixedFeed
-            case 1:
+            case UserViewTab.comments:
                 commentsFeed
-            case 2:
+            case UserViewTab.posts:
                 postsFeed
-            case 3:
+            case UserViewTab.saved:
                 savedFeed
-            default:
-                Text("Coming soon!")
             }
         }
         .environmentObject(privateCommentReplyTracker)

--- a/Mlem/Views/Tabs/Profile/User View.swift
+++ b/Mlem/Views/Tabs/Profile/User View.swift
@@ -68,14 +68,7 @@ struct UserView: View {
         if let user = userDetails {
             if !moderatedCommunities.isEmpty {
                 NavigationLink(value: UserModeratorLink(user: user, moderatedCommunities: moderatedCommunities)) {
-                    Image(systemName: "shield.fill")
-                        .resizable()
-                        .foregroundColor(.green)
-                        .padding(2)
-                        .background(Image(systemName: "shield")
-                            .resizable()
-                            .foregroundColor(Color(UIColor.label))
-                        )
+                    Image(systemName: "shield")
                 }
             }
         }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - #335
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This adds a shield button to the user profile screen if a user moderates any communities.

## Screenshots and Videos

<img src="https://github.com/mormaer/Mlem/assets/1000311/4fed0088-9e86-46a0-82e1-84db1e373f0d" width="40%" />
<img src="https://github.com/mormaer/Mlem/assets/1000311/0c4f72b1-9558-45f7-b658-cd2759acea0b" width="40%" />


<img src="https://github.com/mormaer/Mlem/assets/1000311/52486434-3078-4409-82a6-846131d5a04b" width="40%" />

## Additional Context
This does not flair admins in any way right now.  We don't have a UX spec for that yet.
