### PR TITLE
Remove clipping for Beehaw Avatars

### DIFF
--- a/Mlem/Views/Shared/Links/Community Link View.swift
+++ b/Mlem/Views/Shared/Links/Community Link View.swift
@@ -9,6 +9,26 @@ import Foundation
 import SwiftUI
 import CachedAsyncImage
 
+func shouldClipAvatar(community: APICommunity) -> Bool {
+    let clipOptOut = ["beehaw.org"]
+
+    guard let hostString = community.actorId.host else {
+        return true
+    }
+    
+    return !clipOptOut.contains(hostString)
+}
+
+func shouldClipAvatar(url: URL?) -> Bool {
+    let clipOptOut = ["beehaw.org"]
+
+    guard let hostString = url?.host else {
+        return true
+    }
+    
+    return !clipOptOut.contains(hostString)
+}
+
 struct CommunityLinkView: View {
     // SETTINGS
     // TODO: setting for showing community server instance
@@ -19,60 +39,9 @@ struct CommunityLinkView: View {
     
     var body: some View {
         NavigationLink(value: community) {
-            HStack(alignment: .bottom, spacing: AppConstants.largeAvatarSpacing) {
-                if shouldShowCommunityIcons {
-                    communityAvatar
-                }
-                
-                VStack(alignment: .leading) {
-                    Text(community.name)
-                        .font(.footnote)
-                        .bold()
-                    if showServerInstance, let host = community.actorId.host() {
-                        Text("@\(host)")
-                            .minimumScaleFactor(0.01)
-                            .lineLimit(1)
-                            .opacity(0.6)
-                            .font(.caption)
-                    }
-                }
-                .foregroundColor(.secondary)
-            }
-            .accessibilityElement(children: .combine)
+            CommunityLabel(shouldShowCommunityIcons: shouldShowCommunityIcons,
+                           community: community)
         }
-    }
-    
-    @ViewBuilder
-    private var communityAvatar: some View {
-        Group {
-            if let communityAvatarLink = community.icon {
-                CachedAsyncImage(url: communityAvatarLink, urlCache: AppConstants.urlCache) { image in
-                    if let avatar = image.image {
-                        avatar
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: AppConstants.largeAvatarSize, height: AppConstants.largeAvatarSize)
-                    } else {
-                        defaultCommunityAvatar()
-                    }
-                }
-            } else {
-                defaultCommunityAvatar()
-            }
-        }
-        .frame(width: AppConstants.largeAvatarSize, height: AppConstants.largeAvatarSize)
-        .clipShape(Circle())
-        .overlay(Circle()
-            .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))
-        .accessibilityHidden(true)
-    }
-    
-    private func defaultCommunityAvatar() -> some View {
-        Image(systemName: "building.2.crop.circle.fill")
-            .resizable()
-            .scaledToFit()
-            .frame(width: AppConstants.largeAvatarSize, height: AppConstants.largeAvatarSize)
-            .foregroundColor(.secondary)
     }
 }
 
@@ -87,7 +56,14 @@ struct CommunityLabel: View {
         Group {
             HStack(alignment: .bottom, spacing: AppConstants.largeAvatarSpacing) {
                 if shouldShowCommunityIcons {
-                    communityAvatar
+                    if shouldClipAvatar(community: community) {
+                        communityAvatar
+                            .clipShape(Circle())
+                            .overlay(Circle()
+                                .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))
+                    } else {
+                        communityAvatar
+                    }
                 }
                 
                 VStack(alignment: .leading) {
@@ -127,9 +103,6 @@ struct CommunityLabel: View {
             }
         }
         .frame(width: AppConstants.largeAvatarSize, height: AppConstants.largeAvatarSize)
-        .clipShape(Circle())
-        .overlay(Circle()
-            .stroke(Color(UIColor.secondarySystemBackground), lineWidth: 1))
         .accessibilityHidden(true)
     }
     

--- a/Mlem/Views/Shared/Links/Community Link View.swift
+++ b/Mlem/Views/Shared/Links/Community Link View.swift
@@ -9,9 +9,9 @@ import Foundation
 import SwiftUI
 import CachedAsyncImage
 
-func shouldClipAvatar(community: APICommunity) -> Bool {
-    let clipOptOut = ["beehaw.org"]
+private let clipOptOut = ["beehaw.org"]
 
+func shouldClipAvatar(community: APICommunity) -> Bool {
     guard let hostString = community.actorId.host else {
         return true
     }
@@ -20,8 +20,6 @@ func shouldClipAvatar(community: APICommunity) -> Bool {
 }
 
 func shouldClipAvatar(url: URL?) -> Bool {
-    let clipOptOut = ["beehaw.org"]
-
     guard let hostString = url?.host else {
         return true
     }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header Avatar.swift
@@ -11,18 +11,26 @@ import SwiftUI
 import CachedAsyncImage
 
 struct CommunitySidebarHeaderAvatar: View {
+    @State var shouldClipAvatar: Bool = false
     @State var imageUrl: URL?
 
     var body: some View {
         ZStack {
             if let avatarURL = imageUrl {
                 CachedAsyncImage(url: avatarURL) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .clipShape(Circle())
-                        .overlay(Circle()
-                        .stroke(.secondary, lineWidth: 2))
+                    if shouldClipAvatar {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .clipShape(Circle())
+                            .overlay(Circle()
+                            .stroke(.secondary, lineWidth: 2))
+                    } else {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    }
+
                 } placeholder: {
                     ProgressView()
                 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header Avatar.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header Avatar.swift
@@ -43,7 +43,7 @@ struct CommunitySidebarHeaderAvatar: View {
         }
         .frame(width: 120, height: 120)
         .shadow(radius: 10)
-        .background(Circle()
-        .foregroundColor(.systemBackground))
+        .background(shouldClipAvatar ? Circle()
+            .foregroundColor(.systemBackground) : nil)
     }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sidebar Header.swift
@@ -38,7 +38,8 @@ struct CommunitySidebarHeader: View {
                 }
                 HStack(alignment: .top) {
                     VStack(alignment: .leading) {
-                        CommunitySidebarHeaderAvatar(imageUrl: avatarUrl)
+                        CommunitySidebarHeaderAvatar(shouldClipAvatar: shouldClipAvatar(url: avatarUrl),
+                                                     imageUrl: avatarUrl)
                         
                         Button {
                             if let callback = avatarSubtextClicked {


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [ ] This PR addresses one or more open issues that were assigned to me:
      - *list issue(s) here*
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
No one asked for this, it is a personal thing for me.
I removed the clip circles around Beehaw avatars, as they are hexagonal

## Screenshots and Videos
![Simulator Screenshot - iPhone 14 Pro - 2023-07-01 at 20 01 49](https://github.com/mormaer/Mlem/assets/864259/8c6fdcba-31fd-4df1-93dd-746c2dc29ca1)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-01 at 20 09 07](https://github.com/mormaer/Mlem/assets/864259/2ccab506-111e-4de7-8fd5-dfd9b9d77e48)

