### PR TITLE
Refactor - swipe actions

### DIFF
--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -46,6 +46,16 @@ struct SwipeyView: ViewModifier {
          primaryTrailingAction: SwipeAction?,
          secondaryTrailingAction: SwipeAction?
     ) {
+        assert(
+            secondaryLeadingAction != nil && primaryLeadingAction == nil,
+            "No secondary action should be present without a primary"
+        )
+        
+        assert(
+            secondaryTrailingAction != nil && primaryTrailingAction == nil,
+            "No secondary action should be present without a primary"
+        )
+        
         self.primaryLeadingAction = primaryLeadingAction
         self.secondaryLeadingAction = secondaryLeadingAction
         self.primaryTrailingAction = primaryTrailingAction

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -8,7 +8,13 @@
 import SwiftUI
 
 struct SwipeAction {
-    let symbolName: String
+    
+    struct Symbol {
+        let emptyName: String
+        let fillName: String
+    }
+    
+    let symbol: Symbol
     let colour: Color
     let action: () async -> Void
 }
@@ -33,29 +39,21 @@ struct SwipeyView: ViewModifier {
     let secondaryLeadingAction: SwipeAction?
     let primaryTrailingAction: SwipeAction?
     let secondaryTrailingAction: SwipeAction?
-
-    // symbols
-    let emptyLeadingSymbolName: String
-    let emptyTrailingSymbolName: String
-
+    
     init(isDragging: Binding<Bool>,
-         emptyLeadingSymbolName: String,
          primaryLeadingAction: SwipeAction?,
          secondaryLeadingAction: SwipeAction?,
-         emptyTrailingSymbolName: String,
          primaryTrailingAction: SwipeAction?,
          secondaryTrailingAction: SwipeAction?
     ) {
-        self.emptyLeadingSymbolName = emptyLeadingSymbolName
         self.primaryLeadingAction = primaryLeadingAction
         self.secondaryLeadingAction = secondaryLeadingAction
-        self.emptyTrailingSymbolName = emptyTrailingSymbolName
         self.primaryTrailingAction = primaryTrailingAction
         self.secondaryTrailingAction = secondaryTrailingAction
 
         // other init
-        _leadingSwipeSymbol = State(initialValue: primaryLeadingAction?.symbolName)
-        _trailingSwipeSymbol = State(initialValue: primaryTrailingAction?.symbolName)
+        _leadingSwipeSymbol = State(initialValue: primaryLeadingAction?.symbol.fillName)
+        _trailingSwipeSymbol = State(initialValue: primaryTrailingAction?.symbol.fillName)
         _isDragging = isDragging
     }
 
@@ -104,31 +102,31 @@ struct SwipeyView: ViewModifier {
 
                         // update color and symbol. If crossed an edge, play a gentle haptic
                         if dragPosition < -1 * AppConstants.longSwipeDragMin {
-                            trailingSwipeSymbol = secondaryTrailingAction?.symbolName ?? primaryTrailingAction?.symbolName
+                            trailingSwipeSymbol = secondaryTrailingAction?.symbol.fillName ?? primaryTrailingAction?.symbol.fillName
                             dragBackground = secondaryTrailingAction?.colour ?? primaryTrailingAction?.colour
                             if prevDragPosition >= -1 * AppConstants.longSwipeDragMin, secondaryLeadingAction != nil {
                                 tapper.impactOccurred()
                             }
                         } else if dragPosition < -1 * AppConstants.shortSwipeDragMin {
-                            trailingSwipeSymbol = primaryTrailingAction?.symbolName
+                            trailingSwipeSymbol = primaryTrailingAction?.symbol.fillName
                             dragBackground = primaryTrailingAction?.colour
                             if prevDragPosition >= -1 * AppConstants.shortSwipeDragMin {
                                 tapper.impactOccurred()
                             }
                         } else if dragPosition < 0 {
-                            trailingSwipeSymbol = emptyTrailingSymbolName
+                            trailingSwipeSymbol = primaryTrailingAction?.symbol.emptyName
                             dragBackground = primaryTrailingAction?.colour.opacity(-1 * dragPosition / AppConstants.shortSwipeDragMin)
                         } else if dragPosition < AppConstants.shortSwipeDragMin {
-                            leadingSwipeSymbol = emptyLeadingSymbolName
+                            leadingSwipeSymbol = primaryLeadingAction?.symbol.emptyName
                             dragBackground = primaryLeadingAction?.colour.opacity(dragPosition / AppConstants.shortSwipeDragMin)
                         } else if dragPosition < AppConstants.longSwipeDragMin {
-                            leadingSwipeSymbol = primaryLeadingAction?.symbolName
+                            leadingSwipeSymbol = primaryLeadingAction?.symbol.fillName
                             dragBackground = primaryLeadingAction?.colour
                             if prevDragPosition <= AppConstants.shortSwipeDragMin {
                                 tapper.impactOccurred()
                             }
                         } else {
-                            leadingSwipeSymbol = secondaryLeadingAction?.symbolName ?? primaryLeadingAction?.symbolName
+                            leadingSwipeSymbol = secondaryLeadingAction?.symbol.fillName ?? primaryLeadingAction?.symbol.fillName
                             dragBackground = secondaryLeadingAction?.colour ?? primaryLeadingAction?.colour
                             if prevDragPosition <= AppConstants.longSwipeDragMin, secondaryLeadingAction != nil {
                                 tapper.impactOccurred()
@@ -174,8 +172,8 @@ struct SwipeyView: ViewModifier {
     private func reset() {
         withAnimation(.interactiveSpring()) {
             dragPosition = .zero
-            leadingSwipeSymbol = emptyLeadingSymbolName
-            trailingSwipeSymbol = emptyTrailingSymbolName
+            leadingSwipeSymbol = primaryLeadingAction?.symbol.emptyName
+            trailingSwipeSymbol = primaryTrailingAction?.symbol.emptyName
             dragBackground = .systemBackground
         }
     }
@@ -185,26 +183,20 @@ struct SwipeyView: ViewModifier {
 
 extension View {
     @ViewBuilder
-    // swiftlint:disable function_parameter_count
     func addSwipeyActions(isDragging: Binding<Bool>,
-                          emptyLeadingSymbolName: String,
                           primaryLeadingAction: SwipeAction?,
                           secondaryLeadingAction: SwipeAction?,
-                          emptyTrailingSymbolName: String,
                           primaryTrailingAction: SwipeAction?,
                           secondaryTrailingAction: SwipeAction?
     ) -> some View {
         modifier(
             SwipeyView(
                 isDragging: isDragging,
-                emptyLeadingSymbolName: emptyLeadingSymbolName,
                 primaryLeadingAction: primaryLeadingAction,
                 secondaryLeadingAction: secondaryLeadingAction,
-                emptyTrailingSymbolName: emptyTrailingSymbolName,
                 primaryTrailingAction: primaryTrailingAction,
                 secondaryTrailingAction: secondaryTrailingAction
             )
         )
     }
-    // swiftlint:enable function_parameter_count
 }

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -97,6 +97,11 @@ struct SwipeyView: ViewModifier {
                     if newDragState == .zero {
                         draggingDidEnd()
                     } else {
+                        guard shouldRespondToDragPosition(newDragState) else {
+                            // as swipe actions are optional we don't allow dragging without a primary action
+                            return
+                        }
+                        
                         // update position
                         dragPosition = newDragState
 
@@ -176,6 +181,18 @@ struct SwipeyView: ViewModifier {
             trailingSwipeSymbol = primaryTrailingAction?.symbol.emptyName
             dragBackground = .systemBackground
         }
+    }
+    
+    private func shouldRespondToDragPosition(_ position: CGFloat) -> Bool {
+        if position > 0, primaryLeadingAction == nil {
+            return false
+        }
+        
+        if position < 0, primaryTrailingAction == nil {
+            return false
+        }
+        
+        return true
     }
 }
 // swiftlint:enable cyclomatic_complexity

--- a/Mlem/Extensions/Swipey Actions.swift
+++ b/Mlem/Extensions/Swipey Actions.swift
@@ -15,7 +15,7 @@ struct SwipeAction {
     }
     
     let symbol: Symbol
-    let colour: Color
+    let color: Color
     let action: () async -> Void
 }
 
@@ -118,31 +118,31 @@ struct SwipeyView: ViewModifier {
                         // update color and symbol. If crossed an edge, play a gentle haptic
                         if dragPosition < -1 * AppConstants.longSwipeDragMin {
                             trailingSwipeSymbol = secondaryTrailingAction?.symbol.fillName ?? primaryTrailingAction?.symbol.fillName
-                            dragBackground = secondaryTrailingAction?.colour ?? primaryTrailingAction?.colour
+                            dragBackground = secondaryTrailingAction?.color ?? primaryTrailingAction?.color
                             if prevDragPosition >= -1 * AppConstants.longSwipeDragMin, secondaryLeadingAction != nil {
                                 tapper.impactOccurred()
                             }
                         } else if dragPosition < -1 * AppConstants.shortSwipeDragMin {
                             trailingSwipeSymbol = primaryTrailingAction?.symbol.fillName
-                            dragBackground = primaryTrailingAction?.colour
+                            dragBackground = primaryTrailingAction?.color
                             if prevDragPosition >= -1 * AppConstants.shortSwipeDragMin {
                                 tapper.impactOccurred()
                             }
                         } else if dragPosition < 0 {
                             trailingSwipeSymbol = primaryTrailingAction?.symbol.emptyName
-                            dragBackground = primaryTrailingAction?.colour.opacity(-1 * dragPosition / AppConstants.shortSwipeDragMin)
+                            dragBackground = primaryTrailingAction?.color.opacity(-1 * dragPosition / AppConstants.shortSwipeDragMin)
                         } else if dragPosition < AppConstants.shortSwipeDragMin {
                             leadingSwipeSymbol = primaryLeadingAction?.symbol.emptyName
-                            dragBackground = primaryLeadingAction?.colour.opacity(dragPosition / AppConstants.shortSwipeDragMin)
+                            dragBackground = primaryLeadingAction?.color.opacity(dragPosition / AppConstants.shortSwipeDragMin)
                         } else if dragPosition < AppConstants.longSwipeDragMin {
                             leadingSwipeSymbol = primaryLeadingAction?.symbol.fillName
-                            dragBackground = primaryLeadingAction?.colour
+                            dragBackground = primaryLeadingAction?.color
                             if prevDragPosition <= AppConstants.shortSwipeDragMin {
                                 tapper.impactOccurred()
                             }
                         } else {
                             leadingSwipeSymbol = secondaryLeadingAction?.symbol.fillName ?? primaryLeadingAction?.symbol.fillName
-                            dragBackground = secondaryLeadingAction?.colour ?? primaryLeadingAction?.colour
+                            dragBackground = secondaryLeadingAction?.color ?? primaryLeadingAction?.color
                             if prevDragPosition <= AppConstants.longSwipeDragMin, secondaryLeadingAction != nil {
                                 tapper.impactOccurred()
                             }

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
@@ -146,28 +146,26 @@ struct CommentItem: View {
             .background(Color.systemBackground)
             .addSwipeyActions(
                 isDragging: $isDragging,
-                emptyLeadingSymbolName: emptyVoteSymbolName,
                 primaryLeadingAction: SwipeAction(
-                    symbolName: upvoteSymbolName,
+                    symbol: .init(emptyName: emptyVoteSymbolName, fillName: upvoteSymbolName),
                     colour: .upvoteColor,
                     action: upvote
                 ),
                 secondaryLeadingAction: {
                     guard appState.enableDownvote else { return nil }
                     return SwipeAction(
-                        symbolName: downvoteSymbolName,
+                        symbol: .init(emptyName: "arrow.down.square", fillName: downvoteSymbolName),
                         colour: .downvoteColor,
                         action: downvote
                     )
                 }(),
-                emptyTrailingSymbolName: emptySaveSymbolName,
                 primaryTrailingAction: SwipeAction(
-                    symbolName: saveSymbolName,
+                    symbol: .init(emptyName: emptySaveSymbolName, fillName: saveSymbolName),
                     colour: .saveColor,
                     action: saveComment
                 ),
                 secondaryTrailingAction: SwipeAction(
-                    symbolName: "arrowshape.turn.up.left.fill",
+                    symbol: .init(emptyName: "arrowshape.turn.up.left", fillName: "arrowshape.turn.up.left.fill"),
                     colour: .accentColor,
                     action: replyToComment
                 )

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
@@ -144,21 +144,34 @@ struct CommentItem: View {
                 }
             }
             .background(Color.systemBackground)
-            .addSwipeyActions(isDragging: $isDragging,
-                              emptyLeftSymbolName: emptyVoteSymbolName,
-                              shortLeftSymbolName: upvoteSymbolName,
-                              shortLeftAction: upvote,
-                              shortLeftColor: .upvoteColor,
-                              longLeftSymbolName: appState.enableDownvote ? downvoteSymbolName : nil,
-                              longLeftAction: appState.enableDownvote ? downvote : nil,
-                              longLeftColor: appState.enableDownvote ? .downvoteColor : nil,
-                              emptyRightSymbolName: emptySaveSymbolName,
-                              shortRightSymbolName: saveSymbolName,
-                              shortRightAction: saveComment,
-                              shortRightColor: .saveColor,
-                              longRightSymbolName: "arrowshape.turn.up.left.fill",
-                              longRightAction: replyToComment,
-                              longRightColor: .accentColor)
+            .addSwipeyActions(
+                isDragging: $isDragging,
+                emptyLeadingSymbolName: emptyVoteSymbolName,
+                primaryLeadingAction: SwipeAction(
+                    symbolName: upvoteSymbolName,
+                    colour: .upvoteColor,
+                    action: upvote
+                ),
+                secondaryLeadingAction: {
+                    guard appState.enableDownvote else { return nil }
+                    return SwipeAction(
+                        symbolName: downvoteSymbolName,
+                        colour: .downvoteColor,
+                        action: downvote
+                    )
+                }(),
+                emptyTrailingSymbolName: emptySaveSymbolName,
+                primaryTrailingAction: SwipeAction(
+                    symbolName: saveSymbolName,
+                    colour: .saveColor,
+                    action: saveComment
+                ),
+                secondaryTrailingAction: SwipeAction(
+                    symbolName: "arrowshape.turn.up.left.fill",
+                    colour: .accentColor,
+                    action: replyToComment
+                )
+            )
             .border(width: depth == 0 ? 0 : 2, edges: [.leading], color: threadingColors[depth % threadingColors.count])
             Divider()
 

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
@@ -24,14 +24,7 @@ struct CommentItem: View {
     var displayedVote: ScoringOperation { dirty ? dirtyVote : hierarchicalComment.commentView.myVote ?? .resetVote }
     var displayedScore: Int { dirty ? dirtyScore : hierarchicalComment.commentView.counts.score }
     var displayedSaved: Bool { dirty ? dirtySaved : hierarchicalComment.commentView.saved }
-
-    // TODO: init instead of computed when backend changes come through--this nested computed business is expensive
-    var emptyVoteSymbolName: String { displayedVote == .upvote ? "minus.square" : "arrow.up.square" }
-    var upvoteSymbolName: String { displayedVote == .upvote ? "minus.square.fill" : "arrow.up.square.fill" }
-    var downvoteSymbolName: String { displayedVote == .downvote ? "minus.square.fill" : "arrow.down.square.fill" }
-    var emptySaveSymbolName: String { displayedSaved ? "bookmark.slash" : "bookmark" }
-    var saveSymbolName: String { displayedSaved ? "bookmark.slash.fill" : "bookmark.fill" }
-
+    
     // MARK: Environment
 
     @EnvironmentObject var commentTracker: CommentTracker
@@ -146,29 +139,10 @@ struct CommentItem: View {
             .background(Color.systemBackground)
             .addSwipeyActions(
                 isDragging: $isDragging,
-                primaryLeadingAction: SwipeAction(
-                    symbol: .init(emptyName: emptyVoteSymbolName, fillName: upvoteSymbolName),
-                    colour: .upvoteColor,
-                    action: upvote
-                ),
-                secondaryLeadingAction: {
-                    guard appState.enableDownvote else { return nil }
-                    return SwipeAction(
-                        symbol: .init(emptyName: "arrow.down.square", fillName: downvoteSymbolName),
-                        colour: .downvoteColor,
-                        action: downvote
-                    )
-                }(),
-                primaryTrailingAction: SwipeAction(
-                    symbol: .init(emptyName: emptySaveSymbolName, fillName: saveSymbolName),
-                    colour: .saveColor,
-                    action: saveComment
-                ),
-                secondaryTrailingAction: SwipeAction(
-                    symbol: .init(emptyName: "arrowshape.turn.up.left", fillName: "arrowshape.turn.up.left.fill"),
-                    colour: .accentColor,
-                    action: replyToComment
-                )
+                primaryLeadingAction: upvoteSwipeAction,
+                secondaryLeadingAction: downvoteSwipeAction,
+                primaryTrailingAction: saveSwipeAction,
+                secondaryTrailingAction: replySwipeAction
             )
             .border(width: depth == 0 ? 0 : 2, edges: [.leading], color: threadingColors[depth % threadingColors.count])
             Divider()
@@ -232,5 +206,52 @@ struct CommentItem: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - Swipe Actions
+
+extension CommentItem {
+    
+    private var emptyVoteSymbolName: String { displayedVote == .upvote ? "minus.square" : "arrow.up.square" }
+    private var upvoteSymbolName: String { displayedVote == .upvote ? "minus.square.fill" : "arrow.up.square.fill" }
+    private var emptyDownvoteSymbolName: String { displayedVote == .downvote ? "minus.square" : "arrow.down.square" }
+    private var downvoteSymbolName: String { displayedVote == .downvote ? "minus.square.fill" : "arrow.down.square.fill" }
+    private var emptySaveSymbolName: String { displayedSaved ? "bookmark.slash" : "bookmark" }
+    private var saveSymbolName: String { displayedSaved ? "bookmark.slash.fill" : "bookmark.fill" }
+    private var emptyReplySymbolName: String { "arrowshape.turn.up.left" }
+    private var replySymbolName: String { "arrowshape.turn.up.left.fill" }
+    
+    var upvoteSwipeAction: SwipeAction {
+        SwipeAction(
+            symbol: .init(emptyName: emptyVoteSymbolName, fillName: upvoteSymbolName),
+            colour: .upvoteColor,
+            action: upvote
+        )
+    }
+    
+    var downvoteSwipeAction: SwipeAction? {
+        guard appState.enableDownvote else { return nil }
+        return SwipeAction(
+            symbol: .init(emptyName: emptyDownvoteSymbolName, fillName: downvoteSymbolName),
+            colour: .downvoteColor,
+            action: downvote
+        )
+    }
+    
+    var saveSwipeAction: SwipeAction {
+        SwipeAction(
+            symbol: .init(emptyName: emptySaveSymbolName, fillName: saveSymbolName),
+            colour: .saveColor,
+            action: saveComment
+        )
+    }
+    
+    var replySwipeAction: SwipeAction {
+        SwipeAction(
+           symbol: .init(emptyName: emptyReplySymbolName, fillName: replySymbolName),
+           colour: .accentColor,
+           action: replyToComment
+       )
     }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Comment/Components/Comment Item.swift
@@ -225,7 +225,7 @@ extension CommentItem {
     var upvoteSwipeAction: SwipeAction {
         SwipeAction(
             symbol: .init(emptyName: emptyVoteSymbolName, fillName: upvoteSymbolName),
-            colour: .upvoteColor,
+            color: .upvoteColor,
             action: upvote
         )
     }
@@ -234,7 +234,7 @@ extension CommentItem {
         guard appState.enableDownvote else { return nil }
         return SwipeAction(
             symbol: .init(emptyName: emptyDownvoteSymbolName, fillName: downvoteSymbolName),
-            colour: .downvoteColor,
+            color: .downvoteColor,
             action: downvote
         )
     }
@@ -242,7 +242,7 @@ extension CommentItem {
     var saveSwipeAction: SwipeAction {
         SwipeAction(
             symbol: .init(emptyName: emptySaveSymbolName, fillName: saveSymbolName),
-            colour: .saveColor,
+            color: .saveColor,
             action: saveComment
         )
     }
@@ -250,7 +250,7 @@ extension CommentItem {
     var replySwipeAction: SwipeAction {
         SwipeAction(
            symbol: .init(emptyName: emptyReplySymbolName, fillName: replySymbolName),
-           colour: .accentColor,
+           color: .accentColor,
            action: replyToComment
        )
     }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
@@ -44,15 +44,7 @@ struct FeedPost: View {
     @State var replyIsPresented: Bool = false
     @State var replyContents: String = ""
     @State var replyIsSending: Bool = false
-
-    // MARK: Computed
-    // TODO: real-time swipe-to-vote feedback
-    //    var emptyVoteSymbolName: String { displayedVote == .upvote ? "minus.square" : "arrow.up.square" }
-    //    var upvoteSymbolName: String { displayedVote == .upvote ? "minus.square.fill" : "arrow.up.square.fill" }
-    //    var downvoteSymbolName: String { displayedVote == .downvote ? "minus.square.fill" : "arrow.down.square.fill" }
-    //    var emptySaveSymbolName: String { displayedSaved ? "bookmark.slash" : "bookmark" }
-    //    var saveSymbolName: String { displayedSaved ? "bookmark.slash.fill" : "bookmark.fill" }
-
+    
     var body: some View {
         VStack(spacing: 0) {
             postItem
@@ -68,29 +60,10 @@ struct FeedPost: View {
                 }
                 .addSwipeyActions(
                     isDragging: $isDragging,
-                    primaryLeadingAction: SwipeAction(
-                        symbol: .init(emptyName: "arrow.up.square", fillName: "arrow.up.square.fill"),
-                        colour: .upvoteColor,
-                        action: upvotePost
-                    ),
-                    secondaryLeadingAction: {
-                        guard appState.enableDownvote else { return nil }
-                        return SwipeAction(
-                            symbol: .init(emptyName: "arrow.down.square", fillName: "arrow.down.square.fill"),
-                            colour: .downvoteColor,
-                            action: downvotePost
-                        )
-                    }(),
-                    primaryTrailingAction: SwipeAction(
-                        symbol: .init(emptyName: "bookmark", fillName: "bookmark.fill"),
-                        colour: .saveColor,
-                        action: savePost
-                    ),
-                    secondaryTrailingAction: SwipeAction(
-                        symbol: .init(emptyName: "arrowshape.turn.up.left", fillName: "arrowshape.turn.up.left.fill"),
-                        colour: .accentColor,
-                        action: replyToPost
-                    )
+                    primaryLeadingAction: upvoteSwipeAction,
+                    secondaryLeadingAction: downvoteSwipeAction,
+                    primaryTrailingAction: saveSwipeAction,
+                    secondaryTrailingAction: replySwipeAction
                 )
                 .alert("Not yet implemented!", isPresented: $replyIsPresented) {
                     Button("I love beta apps", role: .cancel) { }
@@ -263,4 +236,53 @@ struct FeedPost: View {
         return ret
     }
     // swiftlint:enable function_body_length
+}
+
+// MARK: - Swipe Actions
+
+extension FeedPost {
+
+    // TODO: if we want to mirror the behaviour in comments here we need the `dirty` operation to be visible from this
+    // context, which at present would require some work as it occurs down inside the post interaction bar
+    // this may need to wait until we complete https://github.com/mormaer/Mlem/issues/117
+    
+//    private var emptyVoteSymbolName: String { displayedVote == .upvote ? "minus.square" : "arrow.up.square" }
+//    private var upvoteSymbolName: String { displayedVote == .upvote ? "minus.square.fill" : "arrow.up.square.fill" }
+//    private var downvoteSymbolName: String { displayedVote == .downvote ? "minus.square.fill" : "arrow.down.square.fill" }
+//    private var emptySaveSymbolName: String { displayedSaved ? "bookmark.slash" : "bookmark" }
+//    private var saveSymbolName: String { displayedSaved ? "bookmark.slash.fill" : "bookmark.fill" }
+    
+    var upvoteSwipeAction: SwipeAction {
+        SwipeAction(
+            symbol: .init(emptyName: "arrow.up.square", fillName: "arrow.up.square.fill"),
+            colour: .upvoteColor,
+            action: upvotePost
+        )
+    }
+    
+    var downvoteSwipeAction: SwipeAction? {
+        guard appState.enableDownvote else { return nil }
+        
+        return SwipeAction(
+            symbol: .init(emptyName: "arrow.down.square", fillName: "arrow.down.square.fill"),
+            colour: .downvoteColor,
+            action: downvotePost
+        )
+    }
+    
+    var saveSwipeAction: SwipeAction {
+        SwipeAction(
+            symbol: .init(emptyName: "bookmark", fillName: "bookmark.fill"),
+            colour: .saveColor,
+            action: savePost
+        )
+    }
+    
+    var replySwipeAction: SwipeAction {
+        SwipeAction(
+            symbol: .init(emptyName: "arrowshape.turn.up.left", fillName: "arrowshape.turn.up.left.fill"),
+            colour: .accentColor,
+            action: replyToPost
+        )
+    }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
@@ -68,28 +68,26 @@ struct FeedPost: View {
                 }
                 .addSwipeyActions(
                     isDragging: $isDragging,
-                    emptyLeadingSymbolName: "arrow.up.square",
                     primaryLeadingAction: SwipeAction(
-                        symbolName: "arrow.up.square.fill",
+                        symbol: .init(emptyName: "arrow.up.square", fillName: "arrow.up.square.fill"),
                         colour: .upvoteColor,
                         action: upvotePost
                     ),
                     secondaryLeadingAction: {
                         guard appState.enableDownvote else { return nil }
                         return SwipeAction(
-                            symbolName: "arrow.down.square.fill",
+                            symbol: .init(emptyName: "arrow.down.square", fillName: "arrow.down.square.fill"),
                             colour: .downvoteColor,
                             action: downvotePost
                         )
                     }(),
-                    emptyTrailingSymbolName: "bookmark",
                     primaryTrailingAction: SwipeAction(
-                        symbolName: "bookmark.fill",
+                        symbol: .init(emptyName: "bookmark", fillName: "bookmark.fill"),
                         colour: .saveColor,
                         action: savePost
                     ),
                     secondaryTrailingAction: SwipeAction(
-                        symbolName: "arrowshape.turn.up.left.fill",
+                        symbol: .init(emptyName: "arrowshape.turn.up.left", fillName: "arrowshape.turn.up.left.fill"),
                         colour: .accentColor,
                         action: replyToPost
                     )

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
@@ -255,7 +255,7 @@ extension FeedPost {
     var upvoteSwipeAction: SwipeAction {
         SwipeAction(
             symbol: .init(emptyName: "arrow.up.square", fillName: "arrow.up.square.fill"),
-            colour: .upvoteColor,
+            color: .upvoteColor,
             action: upvotePost
         )
     }
@@ -265,7 +265,7 @@ extension FeedPost {
         
         return SwipeAction(
             symbol: .init(emptyName: "arrow.down.square", fillName: "arrow.down.square.fill"),
-            colour: .downvoteColor,
+            color: .downvoteColor,
             action: downvotePost
         )
     }
@@ -273,7 +273,7 @@ extension FeedPost {
     var saveSwipeAction: SwipeAction {
         SwipeAction(
             symbol: .init(emptyName: "bookmark", fillName: "bookmark.fill"),
-            colour: .saveColor,
+            color: .saveColor,
             action: savePost
         )
     }
@@ -281,7 +281,7 @@ extension FeedPost {
     var replySwipeAction: SwipeAction {
         SwipeAction(
             symbol: .init(emptyName: "arrowshape.turn.up.left", fillName: "arrowshape.turn.up.left.fill"),
-            colour: .accentColor,
+            color: .accentColor,
             action: replyToPost
         )
     }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Feed Post.swift
@@ -66,21 +66,34 @@ struct FeedPost: View {
                         }
                     }
                 }
-                .addSwipeyActions(isDragging: $isDragging,
-                                  emptyLeftSymbolName: "arrow.up.square",
-                                  shortLeftSymbolName: "arrow.up.square.fill",
-                                  shortLeftAction: upvotePost,
-                                  shortLeftColor: .upvoteColor,
-                                  longLeftSymbolName: appState.enableDownvote ? "arrow.down.square.fill" : nil,
-                                  longLeftAction: appState.enableDownvote ? downvotePost : nil,
-                                  longLeftColor: appState.enableDownvote ? .downvoteColor : nil,
-                                  emptyRightSymbolName: "bookmark",
-                                  shortRightSymbolName: "bookmark.fill",
-                                  shortRightAction: savePost,
-                                  shortRightColor: .saveColor,
-                                  longRightSymbolName: "arrowshape.turn.up.left.fill",
-                                  longRightAction: replyToPost,
-                                  longRightColor: .accentColor)
+                .addSwipeyActions(
+                    isDragging: $isDragging,
+                    emptyLeadingSymbolName: "arrow.up.square",
+                    primaryLeadingAction: SwipeAction(
+                        symbolName: "arrow.up.square.fill",
+                        colour: .upvoteColor,
+                        action: upvotePost
+                    ),
+                    secondaryLeadingAction: {
+                        guard appState.enableDownvote else { return nil }
+                        return SwipeAction(
+                            symbolName: "arrow.down.square.fill",
+                            colour: .downvoteColor,
+                            action: downvotePost
+                        )
+                    }(),
+                    emptyTrailingSymbolName: "bookmark",
+                    primaryTrailingAction: SwipeAction(
+                        symbolName: "bookmark.fill",
+                        colour: .saveColor,
+                        action: savePost
+                    ),
+                    secondaryTrailingAction: SwipeAction(
+                        symbolName: "arrowshape.turn.up.left.fill",
+                        colour: .accentColor,
+                        action: replyToPost
+                    )
+                )
                 .alert("Not yet implemented!", isPresented: $replyIsPresented) {
                     Button("I love beta apps", role: .cancel) { }
                 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Not raised as a specific issue, but as discussed [here](https://github.com/mormaer/Mlem/pull/405#issuecomment-1615939874)
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request
This PR refactors our swipe actions to improve readability and allow for better optionality handling for actions.

- Introduced a `SwipeAction` struct which houses the values that drive each action
- Refactored the code to use this new struct which reduces the number of parameters which must be passed directly to the modifiers initialiser
- Improved support for optionality in the gestures
    - if you do not pass a `secondary` action then only the `primary` will display
    - if you do not pass a `primary` action then a swipe from that edge will be ignored
    - a small `assert` has been added to flag during development if we're passing a `secondary` without a `primary`
- Moved creation of the comment/post actions into extensions to keep the main body of the views less cluttered

## Additional Context
This improves the API of adding swipe actions to our views, as we can now easily support single actions from the leading/trailing edges. We can also choose to supply no actions on one edge, but still support them on the other.

I've left a `TODO` for aligning the behaviour of the icons between comments and posts, comments currently support showing a _undo_ style icon when the action will reset your vote/save etc, but due to the structure of the code in posts this is not possible without a larger change.

This would be best approached after we tackle #117 and properly unify the voting actions.
