### PR TITLE
fix - avoid mapping unused values in `APILocalSite`

### DIFF
--- a/Mlem/API/Models/Site/APILocalSite.swift
+++ b/Mlem/API/Models/Site/APILocalSite.swift
@@ -9,36 +9,36 @@ import Foundation
 
 // lemmy_db_schema::source::local_site::LocalSite
 struct APILocalSite: Decodable {
-    let id: Int
-    let siteId: Int
-    let siteSetup: Bool
+//    let id: Int
+//    let siteId: Int
+//    let siteSetup: Bool
     let enableDownvotes: Bool
-    let enableNsfw: Bool
-    let communityCreationAdminOnly: Bool
-    let requireEmailVerification: Bool
-    let applicationQuestion: String?
-    let privateInstance: Bool
-    let defaultTheme: String
-    let defaultPostListingType: String
-    let legalInformation: String?
-    let hideModlogModNames: Bool
-    let applicationEmailAdmins: Bool
-    let slurFilterRegex: String?
-    let actorNameMaxLength: Int
-    let federationEnabled: Bool
-    let federationDebug: Bool
-    let federationWorkerCount: Int
-    let captchaEnabled: Bool
-    let captchaDifficulty: String
-    let registrationMode: APIRegistrationMode
-    let reportsEmailAdmins: Bool
-    let published: Date
-    let updated: Date?
+//    let enableNsfw: Bool
+//    let communityCreationAdminOnly: Bool
+//    let requireEmailVerification: Bool
+//    let applicationQuestion: String?
+//    let privateInstance: Bool
+//    let defaultTheme: String
+//    let defaultPostListingType: String
+//    let legalInformation: String?
+//    let hideModlogModNames: Bool
+//    let applicationEmailAdmins: Bool
+//    let slurFilterRegex: String?
+//    let actorNameMaxLength: Int
+//    let federationEnabled: Bool
+//    let federationDebug: Bool
+//    let federationWorkerCount: Int
+//    let captchaEnabled: Bool
+//    let captchaDifficulty: String
+//    let registrationMode: APIRegistrationMode
+//    let reportsEmailAdmins: Bool
+//    let published: Date
+//    let updated: Date?
 }
 
 // lemmy_db_schema::source::local_site::RegistrationMode
 enum APIRegistrationMode: String, Codable {
-    case closed = "closed"
-    case requireApplication = "requireapplication"
-    case open = "open"
+    case closed = "Closed"
+    case requireApplication = "RequireApplication"
+    case open = "Open"
 }


### PR DESCRIPTION
# Checklist
- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] I have described what this PR contains
- [x] This PR addresses one or more open issues that were assigned to me:
      - Not an issue, well, it is - but it's not tracked.
- [x] If this PR alters the UI, I have attached pictures/videos

# Pull Request Information

## About this Pull Request

- Yesterday #32 was fixed by #405

- Today Beehaw changed their Lemmy version and the registration enum has changed back to using `UpperCamelCase` and a few other fields have disappeared, breaking our model and causing the site call to fail

Given the above and the fact that as of right now we only require a single value from `APILocalSite` I have removed mapping of the additional properties. I could revert the enumeration change, and remove the two fields I'm seeing fail however we may then start failing to model on instances which have not upgraded and/or start failing tomorrow if Beehaw change something 🙈.

## Additional Context

Our robustness to the API is a much larger issue, commenting the stuff out is not the answer. I have a plan for how we can improve this but it is a larger piece of work. I'll describe it in an issue soon and agree the work with the team.